### PR TITLE
Fix import for cloudwatch_log_stream

### DIFF
--- a/pkg/convertor.go
+++ b/pkg/convertor.go
@@ -92,6 +92,8 @@ func computeResourceID(resource parser.TerraformResource) string {
 		return fmt.Sprintf("%s/%s/%s/%s", v("service_namespace"), v("resource_id"), v("scalable_dimension"), v("name"))
 	case "aws_ecs_service":
 		return fmt.Sprintf("%s/%s", getEcsClusterNameFromARN(v("cluster")), v("name"))
+	case "aws_cloudwatch_log_stream":
+		return fmt.Sprintf("%s:%s", v("log_group_name"), v("name"))
 
 	// gcp resources
 	case "google_bigquery_dataset_iam_member":

--- a/pkg/convertor_test.go
+++ b/pkg/convertor_test.go
@@ -430,6 +430,22 @@ func Test_ComputeTerraformImportForResource(t *testing.T) {
 			},
 		},
 		{
+			name: "For aws_cloudwatch_log_stream",
+			terraformResource: parser.TerraformResource{
+				Address: "aws_cloudwatch_log_stream.test",
+				Type:    "aws_cloudwatch_log_stream",
+				AttributeValues: map[string]any{
+					"log_group_name": "test_log_group",
+					"name":           "TestLogStream123",
+				},
+			},
+			expected: TerraformImport{
+				ResourceAddress: "aws_cloudwatch_log_stream.test",
+				ResourceID:      "test_log_group:TestLogStream123",
+				SupportsImport:  true,
+			},
+		},
+		{
 			name: "For google_monitoring_alert_policy",
 			terraformResource: parser.TerraformResource{
 				Address: "google_monitoring_alert_policy.test",


### PR DESCRIPTION
Adding a custom import for the aws_cloudwatch_log_stream resource. It needs the import format of: log_group_name and name separated by a colon. E.g. TestLogGroup:StreamName