### PR TITLE
fix: add support for aws_route

### DIFF
--- a/pkg/convertor.go
+++ b/pkg/convertor.go
@@ -2,9 +2,10 @@ package tfimportgen
 
 import (
 	"fmt"
-	"github.com/kishaningithub/tf-import-gen/pkg/internal/parser"
 	"slices"
 	"strings"
+
+	"github.com/kishaningithub/tf-import-gen/pkg/internal/parser"
 )
 
 func computeTerraformImportForResource(resource parser.TerraformResource) TerraformImport {
@@ -94,6 +95,8 @@ func computeResourceID(resource parser.TerraformResource) string {
 		return fmt.Sprintf("%s/%s", getEcsClusterNameFromARN(v("cluster")), v("name"))
 	case "aws_cloudwatch_log_stream":
 		return fmt.Sprintf("%s:%s", v("log_group_name"), v("name"))
+	case "aws_route":
+		return fmt.Sprintf("%s_%s", v("route_table_id"), v("destination_cidr_block"))
 
 	// gcp resources
 	case "google_bigquery_dataset_iam_member":


### PR DESCRIPTION
The import blocks for the resource `aws_route` was fallback to the `id` but according to the aws provider docs:

> In Terraform v1.5.0 and later, use an [import block](https://developer.hashicorp.com/terraform/language/import) to import individual routes using ROUTETABLEID_DESTINATION. Import [local routes](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Route_Tables.html#RouteTables) using the VPC's IPv4 or IPv6 CIDR blocks

This implementation only covers IPv4 routes import, some modifications will be needed to support IPv6.

Before:

```hcl
import {
  to = aws_route.public_ig[0]
  id = "r-rtb-0c637fe808f45f0211080289494"
}
```
after
```hcl
import {
  to = aws_route.public_ig[0]
  id = "rtb-0c637fe808f45f021_0.0.0.0/0"
}
```
